### PR TITLE
Created the DynamoDB table / Updated iamRoleStatements for DynamoDB

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,15 @@ provider:
 
 # you can add statements to the Lambda function's IAM Role here
   iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:UpdateItem
+        - dynamodb:DeleteItem
+      Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.DB_TABLE_WEBSITES}"
     - Effect: "Allow"
       Action:
         - "s3:ListBucket"
@@ -92,6 +101,23 @@ functions:
 # you can add CloudFormation resource templates here
 resources:
   Resources:
+    WebsitesTable:
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      Properties:
+        TableName: ${self:provider.environment.DB_TABLE_WEBSITES}
+        AttributeDefinitions:
+          -
+            AttributeName: fqdn # https://ja.wikipedia.org/wiki/Fully_Qualified_Domain_Name
+            AttributeType: S
+        KeySchema:
+          -
+            AttributeName: fqdn
+            KeyType: HASH # Partition key
+        BillingMode: PAY_PER_REQUEST # for On-Demand setting
+        # ProvisionedThroughput: # for Provisioned setting
+          # ReadCapacityUnits: 1
+          # WriteCapacityUnits: 1
     S3BucketResource:
       Type: AWS::S3::Bucket
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,6 +43,7 @@ provider:
 # you can define service wide environment variables here
   environment:
     S3_BUCKET: serverless-crawler-${opt:stage, self:provider.stage}
+    DB_TABLE_WEBSITES: websites-${opt:stage, self:provider.stage}
 
 # you can add packaging information here
 #package:


### PR DESCRIPTION
Appendix:

- provider.environment.DB_TABLE_WEBSITES
  - [serverless frameworkでAWS Lambda+DynamoDBをやってみる ·
  zephiransasのチラシの裏](https://zephiransas.github.io/post/serverless-with-aws/#dymanodb%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B)

- [テーブルの作成 - Amazon DynamoDB](https://docs.aws.amazon.com/ja_jp/amazondynamodb/latest/developerguide/SQLtoNoSQL.CreateTable.html)

- DeletionPolicy:
  - [DeletionPolicy 属性 - AWS CloudFormation](https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html)

- Partition key:
  - [AWS Solutions Architect ブログ: 【AWS Database Blog】DynamoDB におけるパーティションキー設計の手引き](https://aws.typepad.com/sajp/2017/02/choosing-the-right-dynamodb-partition-key.html)

- On-Demand:
  - [DynamoDB On-Demand: When, why and how to use it in your serverless applications](https://serverless.com/blog/dynamodb-on-demand-serverless/)
  - [DynamoDB On-DemandをServerless Framework使って設定してみた #reinvent ｜ DevelopersIO](https://dev.classmethod.jp/cloud/aws/dynamodb-on-demand-serverless-framework-reinvent2018/)

- TableName:
  - [Difference between Web Service and Web Application - Web service vs web application](https://artoftesting.com/manualTesting/difference-between-web-service-and-website.html)